### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/native_library/win/dependencies/geoip.bat
+++ b/native_library/win/dependencies/geoip.bat
@@ -5,8 +5,8 @@ SET SZIP="C:\Program Files\7-Zip\7z.exe"
 echo Downloading geoip...
 git clone https://github.com/maxmind/geoip-api-c.git
 mkdir geoip-api-c\data
-call cscript scripts\wget.js http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz GeoIP.dat.gz
-call cscript scripts\wget.js http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz GeoIPASNum.dat.gz
+call cscript scripts\wget.js https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz GeoIP.dat.gz
+call cscript scripts\wget.js https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz GeoIPASNum.dat.gz
 
 call %SZIP% e %pathtome%GeoIP.dat.gz -o%pathtome%geoip-api-c\data
 


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).